### PR TITLE
Extended functionality

### DIFF
--- a/lib/pokemon-go-mitm.coffee
+++ b/lib/pokemon-go-mitm.coffee
@@ -119,8 +119,9 @@ class PokemonGoMITM
     @log "[+] Request for action #{action}: "
     @log data if data
 
-    if @requestHandlers[action]
-      for handler in @requestHandlers[action]
+    handlers = [].concat @requestHandlers[action] or [], @requestHandlers['*'] or []
+    if handlers.length > 0
+      for handler in handlers
         data = handler data
         unless data
           console.error "Handler for #{action} returned #{data}"
@@ -134,8 +135,9 @@ class PokemonGoMITM
     @log "[+] Response for action #{action}"
     @log data if data
 
-    if @responseHandlers[action]
-      for handler in @responseHandlers[action]
+    handlers = [].concat @responseHandlers[action] or [], @responseHandlers['*'] or []
+    if handlers.length > 0
+      for handler in handlers
         data = handler data
         unless data
           console.error "Handler for #{action} returned #{data}"

--- a/lib/pokemon-go-mitm.coffee
+++ b/lib/pokemon-go-mitm.coffee
@@ -120,7 +120,13 @@ class PokemonGoMITM
     @log data if data
 
     if @requestHandlers[action]
-      return @requestHandlers[action] data
+      for handler in @requestHandlers[action]
+        data = handler data
+        unless data
+          console.error "Handler for #{action} returned #{data}"
+          return false
+
+      return data
 
     false
 
@@ -129,16 +135,31 @@ class PokemonGoMITM
     @log data if data
 
     if @responseHandlers[action]
+      for handler in @responseHandlers[action]
+        data = handler data
+        unless data
+          console.error "Handler for #{action} returned #{data}"
+          return false
+
+      return data
       return @responseHandlers[action] data
 
     false
 
   setResponseHandler: (action, cb) ->
-    @responseHandlers[action] = cb
+    @addResponseHandler action, cb
+
+  addResponseHandler: (action, cb) ->
+    @responseHandlers[action] ?= []
+    @responseHandlers[action].push(cb)
     this
 
   setRequestHandler: (action, cb) ->
-    @requestHandlers[action] = cb
+    @addRequestHandler action, cb
+
+  addRequestHandler: (action, cb) ->
+    @requestHandlers[action] ?= []
+    @requestHandlers[action].push(cb)
     this
 
   log: (text) ->


### PR DESCRIPTION
Easy, 3 commits, 3 features:
- Multiple callbacks, `setRequestHandler` still works but calls `addRequestHandler`
- Wildcard, free to discuss this but it felt an easy quick way to have them: 
  `addRequestHandler '*', (data) -> console.log 'this could be anything'`
- I don't want just the actions but also the actual requests or as we call them, the envelopes: `addRequestEnvelopeHandler`
