### PR TITLE
Make IV display example append IV% to names

### DIFF
--- a/example.pokemonIVdisplay.coffee
+++ b/example.pokemonIVdisplay.coffee
@@ -2,8 +2,7 @@
   Pokemon Go(c) MITM node proxy
   by Michael Strassburger <codepoet@cpan.org>
 
-  Replaces the name of each pokemon with its corresponding IV
-
+  Append the hidden IV% to the end of Pokémon names in our inventory
 ###
 
 PokemonGoMITM = require './lib/pokemon-go-mitm'
@@ -15,12 +14,17 @@ server = new PokemonGoMITM port: 8081
 		data.last_timestamp_ms = 0
 		data
 
-	# Replace all pokemon nicknames with their IVs
+	# Append IV% to existing Pokémon names
 	.addResponseHandler "GetInventory", (data) ->
 		if data.inventory_delta
-			for item in data.inventory_delta.inventory_items
+			for item in data.inventory_delta.inventory_items when item.inventory_item_data
 				if pokemon = item.inventory_item_data.pokemon_data
-					iv = ((pokemon.individual_attack or 0)+(pokemon.individual_defense or 0)+(pokemon.individual_stamina or 0))/45.0*100;
-					iv = Math.floor(iv*10)/10
-					pokemon.nickname = "IV: #{iv}%"
+					id = changeCase.titleCase pokemon.pokemon_id
+					name = pokemon.nickname or id.replace(" Male", "♂").replace(" Female", "♀")
+					atk = pokemon.individual_attack or 0
+					def = pokemon.individual_defense or 0
+					sta = pokemon.individual_stamina or 0
+					iv = Math.round((atk + def + sta) * 100/45)
+					pokemon.nickname = "#{name} #{iv}%"
+
 		data


### PR DESCRIPTION
Merge with my previous version of this script, which also preserves existing nicknames. Makes sorting alphabetically  somewhat useful also (would be better with leading 0s but that seems ugly). Given the range is 0-45, this rounds to the nearest whole percentage instead of including a decimal digit.
