### PR TITLE
Add npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Take a look at the **examples** to get started. Feel happily invited to contribu
 
   `npm install`
 
-* Setup the [CoffeeScript](http://coffeescript.org/) interpreter
+* Setup the [CoffeeScript](http://coffeescript.org/) interpreter (optional if using `npm` scripts)
   `npm install -g coffee-script`
 
 * Prepare your phone to accept the MITM certificate
@@ -42,7 +42,7 @@ Take a look at the **examples** to get started. Feel happily invited to contribu
       * on a jailbroken phone: use [ilendemli](https://github.com/ilendemli)'s nice [patch](https://github.com/ilendemli/trustme/blob/master/packages/info.ilendemli.trustme_0.0.1-1_iphoneos-arm.deb)
       * otherwise: downgrade.
 
-  * Run and quit `coffee example.logTraffic.coffee` to generate a CA certificate
+  * Run and quit `npm start` (or `coffee example.logTraffic.coffee`) to generate a CA certificate
   * Copy the generated `.http-mitm-proxy/certs/ca.pem` to your mobile
   * Add it to the "trusted certificates"
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Pokemon Go MITM proxy",
   "main": "index.js",
   "scripts": {
+    "start": "coffee example.logTraffic.coffee",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
I usually avoid polluting the global environment if possible and this is a perfect example: installing `coffee-script` globally is not needed especially if I probably will never use it again. Instead it's possible to use the `npm` scripts, since the package is already a dependency and `npm` will add `node_modules/.bin` to `$PATH` before running any scripts.
