### PR TITLE
Add PTC auth host to list of endpoints to map to hostname

### DIFF
--- a/lib/pokemon-go-mitm.coffee
+++ b/lib/pokemon-go-mitm.coffee
@@ -18,6 +18,7 @@ class PokemonGoMITM
   endpoint:
     api: 'pgorelease.nianticlabs.com'
     oauth: 'android.clients.google.com'
+    ptc: 'sso.pokemon.com'
     storage: 'storage.googleapis.com'
 
   endpointIPs: {}


### PR DESCRIPTION
I _think_ this is the only PTC SSO host, but correct me if I'm wrong.
