### PR TITLE
Serve ca.crt if present, pass more requests to real endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you are using [pokemon-go-xposed](https://github.com/rastapasta/pokemon-go-xp
 
 * Android N requires a different certificate format, generate it as following and copy the resulting `ca.crt` to your mobile
   ```
-  openssl x509 -outform der -in .http-mitm-proxy/certs/ca.pem -out ca.crt
+  openssl x509 -outform der -in .http-mitm-proxy/certs/ca.pem -out .http-mitm-proxy/certs/ca.crt
   ```
 
 * On very few systems (Raspberry Pi) the CA certificate has to be generated manually:


### PR DESCRIPTION
This passes through GET requests to the real endpoint, whereas the previous version returned 404 for anything not matching `/ca.pem`. Also added `/ca.crt` and updated README to generate it at the correct location.

This makes `handleEndpointRequest` the general handler which we pass a callback to (I used `->` because `this` wrapping should be unnecessary for the call from the @ method at least). I meant to put this refactoring in the last PR before the merge happened. :)
